### PR TITLE
Fix guess result logic

### DIFF
--- a/Ex05.GameLogic/GameManager.cs
+++ b/Ex05.GameLogic/GameManager.cs
@@ -42,35 +42,39 @@ namespace Ex05.GameLogic
             }
 
             int bulls = 0;
-            int pgia = 0;
-
-            bool[] secretUsed = new bool[r_Columns];
-            bool[] guessUsed = new bool[r_Columns];
+            var secretCounts = new Dictionary<eColor, int>();
+            var guessCounts = new Dictionary<eColor, int>();
 
             for (int i = 0; i < r_Columns; i++)
             {
                 if (guess[i] == r_SecretCode[i])
                 {
                     bulls++;
-                    secretUsed[i] = true;
-                    guessUsed[i] = true;
                 }
-            }
 
-            for (int i = 0; i < r_Columns; i++)
-            {
-                if (guessUsed[i]) continue;
-
-                for (int j = 0; j < r_Columns; j++)
+                if (!secretCounts.ContainsKey(r_SecretCode[i]))
                 {
-                    if (!secretUsed[j] && guess[i] == r_SecretCode[j])
-                    {
-                        pgia++;
-                        secretUsed[j] = true;
-                        break;
-                    }
+                    secretCounts[r_SecretCode[i]] = 0;
+                }
+                secretCounts[r_SecretCode[i]]++;
+
+                if (!guessCounts.ContainsKey(guess[i]))
+                {
+                    guessCounts[guess[i]] = 0;
+                }
+                guessCounts[guess[i]]++;
+            }
+
+            int totalMatches = 0;
+            foreach (var color in guessCounts.Keys)
+            {
+                if (secretCounts.TryGetValue(color, out int secretCount))
+                {
+                    totalMatches += Math.Min(secretCount, guessCounts[color]);
                 }
             }
+
+            int pgia = totalMatches - bulls;
 
             GuessResult result = new GuessResult(bulls, pgia);
             Guesses.Add(guess);

--- a/Ex05.GameUI/Forms/GameForm.cs
+++ b/Ex05.GameUI/Forms/GameForm.cs
@@ -131,12 +131,14 @@ namespace Ex05.GameUI.Forms
 
             for (int i = 0; i < result.Bulls; i++)
             {
-                r_ResultButtons[rowIndex][i].BackColor = Color.Black;
+                // Yellow represents a correct color in the correct position
+                r_ResultButtons[rowIndex][i].BackColor = Color.Yellow;
             }
 
             for (int i = result.Bulls; i < result.Bulls + result.Pgia; i++)
             {
-                r_ResultButtons[rowIndex][i].BackColor = Color.Yellow;
+                // Black represents a correct color in a wrong position
+                r_ResultButtons[rowIndex][i].BackColor = Color.Black;
             }
 
             foreach (Button b in r_GuessButtons[rowIndex])


### PR DESCRIPTION
## Summary
- refine calculation of bulls and pgia in `GameManager`
- keep result colors consistent (yellow for bulls, black for pgia)

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68601ba2e2708332bc8e42de1afb56a2