### PR TITLE
Fix guess result tiles

### DIFF
--- a/Ex05.GameLogic/GameManager.cs
+++ b/Ex05.GameLogic/GameManager.cs
@@ -42,35 +42,39 @@ namespace Ex05.GameLogic
             }
 
             int bulls = 0;
-            int pgia = 0;
-
-            bool[] secretUsed = new bool[r_Columns];
-            bool[] guessUsed = new bool[r_Columns];
+            var secretCounts = new Dictionary<eColor, int>();
+            var guessCounts = new Dictionary<eColor, int>();
 
             for (int i = 0; i < r_Columns; i++)
             {
                 if (guess[i] == r_SecretCode[i])
                 {
                     bulls++;
-                    secretUsed[i] = true;
-                    guessUsed[i] = true;
                 }
-            }
 
-            for (int i = 0; i < r_Columns; i++)
-            {
-                if (guessUsed[i]) continue;
-
-                for (int j = 0; j < r_Columns; j++)
+                if (!secretCounts.ContainsKey(r_SecretCode[i]))
                 {
-                    if (!secretUsed[j] && guess[i] == r_SecretCode[j])
-                    {
-                        pgia++;
-                        secretUsed[j] = true;
-                        break;
-                    }
+                    secretCounts[r_SecretCode[i]] = 0;
+                }
+                secretCounts[r_SecretCode[i]]++;
+
+                if (!guessCounts.ContainsKey(guess[i]))
+                {
+                    guessCounts[guess[i]] = 0;
+                }
+                guessCounts[guess[i]]++;
+            }
+
+            int totalMatches = 0;
+            foreach (var color in guessCounts.Keys)
+            {
+                if (secretCounts.TryGetValue(color, out int secretCount))
+                {
+                    totalMatches += Math.Min(secretCount, guessCounts[color]);
                 }
             }
+
+            int pgia = totalMatches - bulls;
 
             GuessResult result = new GuessResult(bulls, pgia);
             Guesses.Add(guess);

--- a/Ex05.GameUI/Forms/GameForm.cs
+++ b/Ex05.GameUI/Forms/GameForm.cs
@@ -129,14 +129,12 @@ namespace Ex05.GameUI.Forms
 
             GuessResult result = r_GameManager.SubmitGuess(guess);
 
-            for (int i = 0; i < result.Bulls; i++)
+            // Indicate guess correctness per position
+            IReadOnlyList<eColor> secret = r_GameManager.SecretCode;
+            for (int i = 0; i < k_Columns; i++)
             {
-                r_ResultButtons[rowIndex][i].BackColor = Color.Black;
-            }
-
-            for (int i = result.Bulls; i < result.Bulls + result.Pgia; i++)
-            {
-                r_ResultButtons[rowIndex][i].BackColor = Color.Yellow;
+                r_ResultButtons[rowIndex][i].BackColor =
+                    guess[i] == secret[i] ? Color.Yellow : Color.Black;
             }
 
             foreach (Button b in r_GuessButtons[rowIndex])


### PR DESCRIPTION
## Summary
- color result tiles per position so correct guesses show yellow
- wrong positions now always show black

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68601ba2e2708332bc8e42de1afb56a2