### PR TITLE
Improve result feedback coloring

### DIFF
--- a/Ex05.GameUI/Forms/GameForm.cs
+++ b/Ex05.GameUI/Forms/GameForm.cs
@@ -129,16 +129,12 @@ namespace Ex05.GameUI.Forms
 
             GuessResult result = r_GameManager.SubmitGuess(guess);
 
-            for (int i = 0; i < result.Bulls; i++)
+            IReadOnlyList<eColor> secret = r_GameManager.SecretCode;
+            for (int i = 0; i < k_Columns; i++)
             {
-                // Yellow represents a correct color in the correct position
-                r_ResultButtons[rowIndex][i].BackColor = Color.Yellow;
-            }
-
-            for (int i = result.Bulls; i < result.Bulls + result.Pgia; i++)
-            {
-                // Black represents a correct color in a wrong position
-                r_ResultButtons[rowIndex][i].BackColor = Color.Black;
+                // Yellow represents a correct guess, black represents an incorrect one
+                r_ResultButtons[rowIndex][i].BackColor =
+                    guess[i] == secret[i] ? Color.Yellow : Color.Black;
             }
 
             foreach (Button b in r_GuessButtons[rowIndex])


### PR DESCRIPTION
## Summary
- color all result squares each round

## Testing
- `dotnet build "Ex05 Lidan 208083501 Revital 212434849.sln"` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602280c87c833295d803e7a6ba1c53